### PR TITLE
Add nip60.signSecret() support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -82,6 +82,10 @@ This feature can be enable / disabled in Options.
 - nip44.encrypt()
 - nip44.decrypt()
 
+[NIP-60](https://github.com/nostr-protocol/nips/blob/master/60.md)
+
+- nip60.[signSecret()](https://github.com/nostr-protocol/nips/pull/1890)
+
 
 
 These javascript functions are made available to web apps through injection of `window.nostr` script element defined in `nostr-provider.js` into the DOM.

--- a/src/common/common.js
+++ b/src/common/common.js
@@ -14,6 +14,7 @@ export const PERMISSION_NAMES = {
   "nip04.decrypt": "decrypt messages from peers",
   "nip44.encrypt": "encrypt messages to peers",
   "nip44.decrypt": "decrypt messages from peers",
+  "nip60.signSecret": "sign cashu secrets using your private key",
 };
 
 function matchConditions(conditions, event) {

--- a/src/popup/components/PermissionItem.tsx
+++ b/src/popup/components/PermissionItem.tsx
@@ -42,6 +42,9 @@ export function PermissionItem(props: {
     case "nip04.decrypt":
       strMesg = "decrypt received messages";
       break;
+    case "nip60.signSecret":
+      strMesg = "decrypt received messages";
+      break;
     case "signEvent":
       if (strEvents != "") {
         strMesg = `sign ${strEvents} events`;

--- a/src/static/manifest.json
+++ b/src/static/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "AKA Profiles",
   "description": "Nostr Signer Extension supporting multiple public / private key pairs.",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "manifest_version": 3,
   "action": {
     "default_popup": "app.html",

--- a/src/static/nostr-provider.js
+++ b/src/static/nostr-provider.js
@@ -38,6 +38,12 @@ window.nostr = {
     },
   },
 
+  nip60: {
+    async signSecret(secret) {
+      return window.nostr._call('nip60.signSecret', {secret});
+    },
+  },
+
   // send request to contentScript.js
   _call(type, params) {
     // console.log("[np] sending mesg to [cs]: " + type + " " + JSON.stringify(params));


### PR DESCRIPTION
Adds optional nip60.signSecret() support as specified in https://github.com/nostr-protocol/nips/pull/1890

This method deepens the interoperability between Nostr and Cashu. Although there is overlap in outcomes vs signString(), this is a much more Nostr-friendly approach to structured external string signing.